### PR TITLE
fix(validate-config): key full-document validator cache by section set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `validate-config`: full-document validation no longer reports false-positive `additionalProperties` errors on valid multi-section `vcluster.yaml` files. Compiled full-document validators were cached under a key that ignored which top-level sections the document contained, so the first document validated in a process fixed the allowed section set for every later document of the same version (DOC-1628).
+
 ## [1.5.0] - 2026-03-15
 
 ### Added

--- a/src/snippet-validator.ts
+++ b/src/snippet-validator.ts
@@ -267,7 +267,16 @@ export function validateSnippet(
   if (isFullDocument) {
     // Multiple top-level sections = validate as full document
     section = '__full_document__';
-    cacheKey = `__full__:${version}`;
+    // The synthetic schema below is built from exactly the sections present in
+    // this document and uses additionalProperties:false. The cache key must
+    // therefore encode that section set. A fixed `__full__:${version}` key made
+    // the first full document's validator get reused for every later full
+    // document of the same version, so any section absent from the first
+    // document was flagged as a false-positive additionalProperties error
+    // (DOC-1628). Sort so key order within a document does not spawn duplicate
+    // cache entries.
+    const sectionSetKey = [...matchingSections].sort().join(',');
+    cacheKey = `__full__:${sectionSetKey}:${version}`;
 
     // Build schema with only the sections present in the snippet
     const snippetSchema: JsonSchema = {

--- a/tests/validation-errors.test.js
+++ b/tests/validation-errors.test.js
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { validateSnippet } from '../src/snippet-validator.ts';
+import { validateSnippet, clearCache } from '../src/snippet-validator.ts';
 import { githubClient } from '../src/github.ts';
 
 describe('Validation Error Detection', () => {
@@ -281,6 +281,120 @@ controlPlane:
         e.keyword === 'additionalProperties'
       );
       expect(hasAdditionalPropsError).toBe(true);
+    });
+  });
+
+  // DOC-1628: full-document validators were cached under a fixed
+  // `__full__:<version>` key that ignored which top-level sections the
+  // document contained. The first full document validated in a process
+  // therefore poisoned the cache for every later full document of the same
+  // version: any section absent from the first document was reported as a
+  // false-positive additionalProperties error. The failure is order-dependent
+  // across validate() calls, which is why it only appears once more than one
+  // multi-section document is validated in the same session.
+  describe('Multi-key document order-independence (DOC-1628)', () => {
+    // Two valid full documents whose top-level section sets differ.
+    const docControlPlaneExport = `
+controlPlane:
+  proxy:
+    extraSANs:
+      - "vcluster-demo.vcluster-demo.svc.cluster.local"
+exportKubeConfig:
+  server: https://vcluster-name.vcluster-namespace.svc.cluster.local:443
+  insecure: true
+  additionalSecrets:
+  - name: vcluster-flux-kubeconfig
+`;
+    const docControlPlaneSync = `
+controlPlane:
+  backingStore:
+    etcd:
+      embedded:
+        enabled: true
+  ingress:
+    enabled: true
+    host: vcluster-k8s-api.example.com
+sync:
+  toHost:
+    serviceAccounts:
+      enabled: true
+`;
+
+    it('does not flag a valid section absent from the previously validated document', () => {
+      clearCache();
+
+      // Prime the cache with a document that has no `sync` section.
+      const first = validateSnippet(docControlPlaneExport, fullSchema, version);
+      expect(first.valid).toBe(true);
+
+      // Before the fix this reused the primed validator and reported
+      // additionalProperty: sync even though `sync` is a valid top-level key.
+      const second = validateSnippet(docControlPlaneSync, fullSchema, version);
+      expect(second.section).toBe('__full_document__');
+      expect(second.errors ?? []).toEqual([]);
+      expect(second.valid).toBe(true);
+    });
+
+    it('is symmetric under reversed validation order', () => {
+      clearCache();
+
+      // Prime with a document that has no `exportKubeConfig` section.
+      const first = validateSnippet(docControlPlaneSync, fullSchema, version);
+      expect(first.valid).toBe(true);
+
+      const second = validateSnippet(docControlPlaneExport, fullSchema, version);
+      expect(second.section).toBe('__full_document__');
+      expect(second.errors ?? []).toEqual([]);
+      expect(second.valid).toBe(true);
+    });
+
+    it('reproduces the issue backingStore + ingress + sync case after a differing full document', () => {
+      clearCache();
+
+      // A different multi-section document primes the cache first.
+      validateSnippet(docControlPlaneExport, fullSchema, version);
+
+      const yaml = `
+controlPlane:
+  backingStore:
+    etcd:
+      embedded:
+        enabled: true
+  ingress:
+    enabled: true
+    host: vcluster-k8s-api.example.com
+sync:
+  toHost:
+    serviceAccounts:
+      enabled: true
+`;
+      const result = validateSnippet(yaml, fullSchema, version);
+      expect(result.valid).toBe(true);
+      expect(result.errors ?? []).toEqual([]);
+    });
+
+    it('still flags genuinely invalid top-level keys after a valid full document primes the cache', () => {
+      clearCache();
+
+      // Prime with a valid full document.
+      const primed = validateSnippet(docControlPlaneSync, fullSchema, version);
+      expect(primed.valid).toBe(true);
+
+      // A real typo at the top level must still be rejected: the fix must not
+      // make additionalProperties detection permissive.
+      const yaml = `
+controlPlane:
+  distro:
+    k3s:
+      enabled: true
+totallyBogusTopLevelKey: true
+`;
+      const result = validateSnippet(yaml, fullSchema, version);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e =>
+        e.keyword === 'additionalProperties' &&
+        e.params.additionalProperty === 'totallyBogusTopLevelKey'
+      )).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

`validate-config` reported false-positive `additionalProperties` errors on valid multi-section `vcluster.yaml` documents, and the pass/fail result flipped depending on validation order (DOC-1628). This fixes the root cause in the validator's full-document caching.

## Root cause

The full-document branch of `validateSnippet` (`src/snippet-validator.ts`) builds a synthetic schema from **only the top-level sections present in the current document**, with `additionalProperties: false`, then caches the compiled ajv validator under a fixed key `__full__:<version>`.

That key ignores which sections the document contained. The first full document validated in a process compiled and cached the validator; every later full document of the same version reused it. Any valid top-level section absent from that first document (for example `sync`, `policies`, `platform`) was then flagged as an additional property. Each section still validated correctly when submitted alone, because the single-section path uses a per-section cache key (`<section>:<version>`).

The order-dependence in the issue is across `validate()` calls in one server session, not key order inside a single document.

## Key changes

- `src/snippet-validator.ts`: encode the sorted set of matching top-level sections in the full-document cache key (`__full__:<sortedSections>:<version>`). Documents with different section sets now compile distinct validators; identical section sets in any key order still share one cached validator.
- `tests/validation-errors.test.js`: regression tests under `Multi-key document order-independence (DOC-1628)` that prime the cache with one multi-section document and assert a second document with a different section set is not falsely rejected, in both orders, reproduce the issue's `backingStore + ingress + sync` case, and guard that genuinely invalid top-level keys are still rejected.
- `CHANGELOG.md`: Unreleased `Fixed` entry.

## Verification

- New regression tests fail against the unfixed source with the exact issue errors (`additionalProperty: sync`, `additionalProperty: exportKubeConfig`) and pass with the fix.
- Full suite green: `npx vitest run` -> 316 passed (25 files). `tsc --noEmit` clean.
- All three repro cases from the issue validate `valid: true`, independent of validation order.

## Dependencies

None.

## TODO

- [x] Root cause identified in full-document schema/validator resolution
- [x] False positive no longer reproduces for the three repro cases
- [x] Regression test added covering multi-key document order-independence

Closes DOC-1628