### PR TITLE
chore(release): 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.5.1] - 2026-07-23
 
 ### Fixed
 - `validate-config`: full-document validation no longer reports false-positive `additionalProperties` errors on valid multi-section `vcluster.yaml` files. Compiled full-document validators were cached under a key that ignored which top-level sections the document contained, so the first document validated in a process fixed the allowed section set for every later document of the same version (DOC-1628).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vcluster-yaml-mcp-server",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vcluster-yaml-mcp-server",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.26.0",
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vcluster-yaml-mcp-server",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "MCP server for querying vcluster YAML configurations using jq",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Release prep for 1.5.1. Finalizes the CHANGELOG `Unreleased` section as `[1.5.1]` and bumps `package.json`/`package-lock.json` to 1.5.1 so the Release workflow's changelog gate passes.

1.5.1 ships a single fix: the `validate-config` full-document cache-key collision that produced false `additionalProperties` errors on valid multi-section documents (DOC-1628, merged in #76). No dependency bumps are included in this release.

## Key Changes

- `CHANGELOG.md`: `## [Unreleased]` -> `## [1.5.1] - 2026-07-23`.
- `package.json` / `package-lock.json`: 1.5.0 -> 1.5.1.

## Dependencies

Depends on #76 (already merged).

## TODO

- [ ] Merge, then dispatch `release.yml` with version=1.5.1

References DOC-1628